### PR TITLE
add agreement details dialog to data transfers view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+# [0.6.3] - 19-06-2026
+
+### Added
+
+- Agreement details dialog in the Data Transfers view — clicking the Agreement ID on a completed transfer opens a modal with full agreement metadata, permissions, constraints, and remaining transfer count
+
 # [0.6.2] - 08-04-2026
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tc-dsp-ui",
-  "version": "0.6.2-dev",
+  "version": "0.6.3-dev",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,9 @@
+# [0.6.3] - 19-06-2026
+
+### Added
+
+- Agreement details dialog in the Data Transfers view — clicking the Agreement ID on a completed transfer opens a modal with full agreement metadata, permissions, constraints, and remaining transfer count
+
 # [0.6.0] - 25-11-2025
 
 ### Changed

--- a/src/app/components/catalog-browser/catalog-browser-details/cn-details-dialog/cn-details-dialog.component.html
+++ b/src/app/components/catalog-browser/catalog-browser-details/cn-details-dialog/cn-details-dialog.component.html
@@ -103,7 +103,12 @@
                 >
                   <span class="operand">{{ constraint.leftOperand }}</span>
                   <span class="operator">{{ constraint.operator }}</span>
-                  <span class="operand">{{ constraint.rightOperand }}</span>
+                  <span class="operand"> @if(isDateConstraint(constraint)) {
+                        {{ constraint.rightOperand | date: 'd MMM y, HH:mm' }}
+                        }
+                        @else { {{ constraint.rightOperand }} }
+                      </span>
+                    <!-- {{ constraint.rightOperand }}</span> -->
                 </div>
               </div>
             </div>

--- a/src/app/components/catalog-browser/catalog-browser-details/cn-details-dialog/cn-details-dialog.component.ts
+++ b/src/app/components/catalog-browser/catalog-browser-details/cn-details-dialog/cn-details-dialog.component.ts
@@ -4,6 +4,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { Constraint } from '../../../../models/permission';
 
 @Component({
     selector: 'app-cn-details-dialog',
@@ -27,5 +28,9 @@ export class CnDetailsDialogComponent {
    * */
   onClose(): void {
     this.dialogRef.close();
+  }
+
+  isDateConstraint(constraint: Constraint): boolean {
+    return constraint.leftOperand === 'DATE_TIME';
   }
 }

--- a/src/app/components/data-transfers/agreement-details-dialog/agreement-details-dialog.component.css
+++ b/src/app/components/data-transfers/agreement-details-dialog/agreement-details-dialog.component.css
@@ -1,0 +1,315 @@
+.dialog {
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
+  border-radius: 12px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 24px;
+  border-bottom: 1px solid #f0f0f0;
+  background: linear-gradient(135deg, #f5f3ff 0%, #fef9f3 100%);
+}
+
+.header-left h1 {
+  margin: 0;
+  color: #383838;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.close-btn {
+  flex-shrink: 0;
+  color: #383838 !important;
+  transition: all 0.2s ease !important;
+}
+
+.close-btn:hover {
+  color: #6200ea !important;
+  transform: scale(1.1);
+}
+
+.card-body {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.loading-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40px;
+}
+
+.agreement-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  background-color: #ffffff;
+  border-radius: 12px;
+  border-left: 4px solid #d946a6;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.section-header mat-icon {
+  color: #d946a6;
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+.section-header h3 {
+  margin: 0;
+  color: #383838;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.agreement-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.agreement-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.item-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #9b9b9b;
+  font-weight: 600;
+}
+
+.item-value {
+  font-size: 14px;
+  color: #383838;
+  word-break: break-word;
+  font-weight: 500;
+}
+
+.permissions-panel {
+  background-color: #ffffff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  border: 1px solid #e8e8e8;
+  transition: box-shadow 0.2s ease;
+}
+
+.permissions-panel:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+::ng-deep .permissions-panel .mat-expansion-panel-header {
+  background-color: #ffffff !important;
+  padding: 12px 16px !important;
+  height: auto !important;
+  min-height: 48px !important;
+  border-bottom: 1px solid #f0f0f0 !important;
+}
+
+::ng-deep .permissions-panel .mat-expansion-panel-header.mat-expanded {
+  background-color: #f5f3ff !important;
+}
+
+::ng-deep .permissions-panel .mat-panel-title {
+  display: flex !important;
+  align-items: center !important;
+  gap: 8px !important;
+  color: #383838 !important;
+  font-weight: 600 !important;
+  font-size: 14px !important;
+}
+
+::ng-deep .permissions-panel .mat-panel-title mat-icon {
+  font-size: 18px !important;
+  width: 18px !important;
+  height: 18px !important;
+  color: #d946a6 !important;
+}
+
+::ng-deep .permissions-panel .mat-expansion-panel-body {
+  padding: 0 !important;
+}
+
+.permission-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  margin-left: auto;
+  margin-right: 8px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #ffc0d9 0%, #ff9ec9 100%);
+  color: #a61747;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.permissions-content {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.permission-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.permission-card:last-child {
+  border-bottom: none;
+}
+
+.permission-card-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.permission-action {
+  font-size: 13px;
+  font-weight: 600;
+  color: #383838;
+  text-transform: capitalize;
+}
+
+.permission-counter {
+  font-size: 11px;
+  color: #9b9b9b;
+  font-weight: 500;
+}
+
+.permission-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.info-row {
+  display: flex;
+  gap: 10px;
+  font-size: 12px;
+  align-items: flex-start;
+}
+
+.info-label {
+  color: #6b6b6b;
+  font-weight: 500;
+  min-width: 70px;
+  flex-shrink: 0;
+}
+
+.info-value {
+  color: #383838;
+  word-break: break-word;
+  flex: 1;
+}
+
+.permission-constraints {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.constraints-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #383838;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.constraint-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.constraint-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  flex-wrap: wrap;
+}
+
+.operand {
+  color: #383838;
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.operator {
+  color: #383838;
+  font-weight: 700;
+  flex-shrink: 0;
+  padding: 0 4px;
+}
+
+.error-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  color: #9b9b9b;
+  gap: 8px;
+}
+
+.error-container mat-icon {
+  font-size: 40px;
+  width: 40px;
+  height: 40px;
+  color: #b13636;
+}
+
+.error-container p {
+  margin: 0;
+  font-size: 14px;
+  color: #646464;
+}
+
+@media (max-width: 768px) {
+  .card-header {
+    padding: 16px;
+  }
+
+  .card-body {
+    padding: 16px;
+  }
+
+  .header-left h1 {
+    font-size: 16px;
+  }
+}

--- a/src/app/components/data-transfers/agreement-details-dialog/agreement-details-dialog.component.html
+++ b/src/app/components/data-transfers/agreement-details-dialog/agreement-details-dialog.component.html
@@ -1,0 +1,118 @@
+<div class="dialog">
+  <div class="card-header">
+    <div class="header-left">
+      <h1>Agreement Details</h1>
+    </div>
+    <button mat-icon-button (click)="onClose()" class="close-btn" aria-label="Close dialog">
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+
+  <div class="card-body">
+    <div *ngIf="loading" class="loading-container">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+
+    <ng-container *ngIf="!loading && agreement">
+      <div class="agreement-section">
+        <div class="section-header">
+          <mat-icon>handshake</mat-icon>
+          <h3>Agreement Information</h3>
+        </div>
+        <div class="agreement-content">
+          <div class="agreement-item">
+            <span class="item-label">Agreement ID</span>
+            <span class="item-value">{{ agreement['@id'] }}</span>
+          </div>
+          <div class="agreement-item">
+            <span class="item-label">Assigner</span>
+            <span class="item-value">{{ agreement.assigner }}</span>
+          </div>
+          <div class="agreement-item">
+            <span class="item-label">Assignee</span>
+            <span class="item-value">{{ agreement.assignee }}</span>
+          </div>
+          <div class="agreement-item">
+            <span class="item-label">Target</span>
+            <span class="item-value">{{ agreement.target }}</span>
+          </div>
+          <div class="agreement-item">
+            <span class="item-label">Timestamp</span>
+            <span class="item-value">{{ agreement.timestamp | date: 'd MMM y, HH:mm' }}</span>
+          </div>
+        </div>
+      </div>
+
+      <mat-expansion-panel
+        class="permissions-panel"
+        *ngIf="agreement.permission && agreement.permission.length > 0"
+      >
+        <mat-expansion-panel-header>
+          <mat-panel-title>
+            <mat-icon>security</mat-icon>
+            Permissions
+          </mat-panel-title>
+          <span class="permission-count">{{ agreement.permission.length }}</span>
+        </mat-expansion-panel-header>
+
+        <div class="permissions-content">
+          <div
+            *ngFor="let permission of agreement.permission; let i = index"
+            class="permission-card"
+          >
+            <div class="permission-card-title">
+              <span class="permission-action">{{ permission.action }}</span>
+              <span class="permission-counter">{{ i + 1 }} / {{ agreement.permission.length }}</span>
+            </div>
+
+            <div class="permission-info">
+              <div class="info-row" *ngIf="permission.assignee">
+                <span class="info-label">Assignee</span>
+                <span class="info-value">{{ permission.assignee }}</span>
+              </div>
+              <div class="info-row" *ngIf="permission.assigner">
+                <span class="info-label">Assigner</span>
+                <span class="info-value">{{ permission.assigner }}</span>
+              </div>
+              <div class="info-row" *ngIf="permission.target">
+                <span class="info-label">Target</span>
+                <span class="info-value">{{ permission.target }}</span>
+              </div>
+            </div>
+
+            <div
+              *ngIf="permission.constraint && permission.constraint.length > 0"
+              class="permission-constraints"
+            >
+              <div class="constraints-title">Constraints ({{ permission.constraint.length }})</div>
+              <div class="constraint-list">
+                <div
+                  *ngFor="let constraint of permission.constraint"
+                  class="constraint-row"
+                >
+                  <span class="operand">{{ constraint.leftOperand }}</span>
+                  <span class="operator">{{ constraint.operator }}</span>
+
+                  <span class="operand">@if (isDateConstraint(constraint)) {
+                    {{ constraint.rightOperand | date: 'd MMM y, HH:mm' }}
+                  } @else {
+                    {{ constraint.rightOperand }}
+                  }</span>
+                  <span> @if (isCountConstraint(constraint)) {
+                    ({{ getRemainingCount(constraint) }})
+                  }
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </mat-expansion-panel>
+    </ng-container>
+
+    <div *ngIf="!loading && !agreement" class="error-container">
+      <mat-icon>error_outline</mat-icon>
+      <p>Agreement details could not be loaded.</p>
+    </div>
+  </div>
+</div>

--- a/src/app/components/data-transfers/agreement-details-dialog/agreement-details-dialog.component.spec.ts
+++ b/src/app/components/data-transfers/agreement-details-dialog/agreement-details-dialog.component.spec.ts
@@ -1,0 +1,127 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { of, throwError } from 'rxjs';
+import { Agreement } from '../../../models/agreement';
+import { Constraint } from '../../../models/permission';
+import { Operator } from '../../../models/enums/operators.enum';
+import { AgreementService } from '../../../services/agreement/agreement.service';
+import { AgreementDetailsDialogComponent } from './agreement-details-dialog.component';
+
+describe('AgreementDetailsDialogComponent', () => {
+  let component: AgreementDetailsDialogComponent;
+  let fixture: ComponentFixture<AgreementDetailsDialogComponent>;
+  let mockAgreementService: jasmine.SpyObj<AgreementService>;
+
+  const mockAgreement: Agreement = {
+    '@id': 'test-agreement-id',
+    assigner: 'urn:uuid:provider',
+    assignee: 'urn:uuid:consumer',
+    target: 'urn:uuid:dataset',
+    timestamp: '2024-01-15T10:00:00Z',
+    permission: [
+      {
+        action: 'USE',
+        constraint: [
+          { leftOperand: 'DATE_TIME', operator: Operator.LTEQ, rightOperand: '2025-12-31T23:59:59Z' },
+          { leftOperand: 'COUNT', operator: Operator.LTEQ, rightOperand: '10' },
+        ],
+      },
+    ],
+    currentCount: 3,
+  };
+
+  const mockDialogRef = {
+    close: jasmine.createSpy('close'),
+  };
+
+  beforeEach(async () => {
+    mockAgreementService = jasmine.createSpyObj('AgreementService', ['getAgreementById']);
+    mockAgreementService.getAgreementById.and.returnValue(of(mockAgreement));
+
+    await TestBed.configureTestingModule({
+      imports: [AgreementDetailsDialogComponent, BrowserAnimationsModule],
+      providers: [
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: { agreementId: 'test-agreement-id' } },
+        { provide: AgreementService, useValue: mockAgreementService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AgreementDetailsDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load agreement details on init', () => {
+    expect(mockAgreementService.getAgreementById).toHaveBeenCalledWith('test-agreement-id');
+    expect(component.agreement).toEqual(mockAgreement);
+    expect(component.loading).toBeFalse();
+  });
+
+  it('should set loading to false on API error', () => {
+    mockAgreementService.getAgreementById.and.returnValue(throwError(() => new Error('API error')));
+    component.loading = true;
+    component.ngOnInit();
+    expect(component.loading).toBeFalse();
+  });
+
+  it('should close dialog when onClose is called', () => {
+    component.onClose();
+    expect(mockDialogRef.close).toHaveBeenCalled();
+  });
+
+  describe('isDateConstraint', () => {
+    it('should return true for DATE_TIME left operand', () => {
+      const constraint: Constraint = { leftOperand: 'DATE_TIME', operator: Operator.LTEQ, rightOperand: '2025-12-31' };
+      expect(component.isDateConstraint(constraint)).toBeTrue();
+    });
+
+    it('should return false for non-date left operand', () => {
+      const constraint: Constraint = { leftOperand: 'COUNT', operator: Operator.LTEQ, rightOperand: '10' };
+      expect(component.isDateConstraint(constraint)).toBeFalse();
+    });
+  });
+
+  describe('isCountConstraint', () => {
+    it('should return true for COUNT left operand', () => {
+      const constraint: Constraint = { leftOperand: 'COUNT', operator: Operator.LTEQ, rightOperand: '5' };
+      expect(component.isCountConstraint(constraint)).toBeTrue();
+    });
+
+    it('should return false for non-count left operand', () => {
+      const constraint: Constraint = { leftOperand: 'DATE_TIME', operator: Operator.LTEQ, rightOperand: '2025-12-31' };
+      expect(component.isCountConstraint(constraint)).toBeFalse();
+    });
+  });
+
+  describe('getRemainingCount', () => {
+    it('should return plural remaining count for LTEQ operator', () => {
+      // currentCount=3, rightOperand='10' → remaining = 10 - 3 = 7
+      const constraint: Constraint = { leftOperand: 'COUNT', operator: Operator.LTEQ, rightOperand: '10' };
+      expect(component.getRemainingCount(constraint)).toBe('7 remaining transfers');
+    });
+
+    it('should return singular remaining count for LT operator', () => {
+      // currentCount=3, rightOperand='5' → remaining = 5-1-3 = 1
+      const constraint: Constraint = { leftOperand: 'COUNT', operator: Operator.LT, rightOperand: '5' };
+      expect(component.getRemainingCount(constraint)).toBe('1 remaining transfer');
+    });
+
+    it('should return "No remaining transfers" when count is exhausted', () => {
+      // currentCount=3, rightOperand='3' → remaining = 3 - 3 = 0
+      const constraint: Constraint = { leftOperand: 'COUNT', operator: Operator.LTEQ, rightOperand: '3' };
+      expect(component.getRemainingCount(constraint)).toBe('No remaining transfers');
+    });
+
+    it('should return singular "1 remaining transfer" for exactly 1 left', () => {
+      // currentCount=3, rightOperand='4' → remaining = 4 - 3 = 1
+      const constraint: Constraint = { leftOperand: 'COUNT', operator: Operator.LTEQ, rightOperand: '4' };
+      expect(component.getRemainingCount(constraint)).toBe('1 remaining transfer');
+    });
+  });
+});

--- a/src/app/components/data-transfers/agreement-details-dialog/agreement-details-dialog.component.ts
+++ b/src/app/components/data-transfers/agreement-details-dialog/agreement-details-dialog.component.ts
@@ -1,0 +1,83 @@
+import { CommonModule } from '@angular/common';
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { Agreement } from '../../../models/agreement';
+import { AgreementService } from '../../../services/agreement/agreement.service';
+import { Constraint } from '../../../models/permission';
+import { Operator } from '../../../models/enums/operators.enum';
+
+@Component({
+  selector: 'app-agreement-details-dialog',
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatIconModule,
+    MatExpansionModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './agreement-details-dialog.component.html',
+  styleUrl: './agreement-details-dialog.component.css',
+})
+export class AgreementDetailsDialogComponent implements OnInit {
+  agreement: Agreement | null = null;
+  loading = true;
+
+  constructor(
+    public dialogRef: MatDialogRef<AgreementDetailsDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { agreementId: string },
+    private agreementService: AgreementService,
+  ) {}
+
+  ngOnInit(): void {
+    this.agreementService.getAgreementById(this.data.agreementId).subscribe({
+      next: (agreement) => {
+        this.agreement = agreement;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      },
+    });
+  }
+
+  onClose(): void {
+    this.dialogRef.close();
+  }
+
+  isDateConstraint(constraint: Constraint): boolean {
+    return constraint.leftOperand === 'DATE_TIME';
+  }
+
+  isCountConstraint(constraint: Constraint): boolean {
+    return constraint.leftOperand === 'COUNT';
+  }
+
+  getRemainingCount(constraint: Constraint): string {
+    let remaining: number=0;
+    if (constraint.operator === Operator.LTEQ) {
+      remaining =
+        parseInt(constraint.rightOperand) - (this.agreement?.currentCount ?? 0);
+    } 
+    if (constraint.operator === Operator.LT) {
+      remaining =
+        parseInt(constraint.rightOperand)-1 - (this.agreement?.currentCount ?? 0);
+    }
+    
+    if (remaining <= 0) {
+        return 'No remaining transfers';
+      }
+     if (remaining === 1) {
+        return '1 remaining transfer';
+      }
+
+      return `${remaining} remaining transfers`;
+    } 
+  
+
+  
+}

--- a/src/app/components/data-transfers/data-transfers.component.css
+++ b/src/app/components/data-transfers/data-transfers.component.css
@@ -320,6 +320,12 @@ mat-icon.help-icon {
   justify-content: flex-start;
 }
 
+.metadata-value-action {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .metadata-label {
   font-size: 12px;
   font-weight: 600;

--- a/src/app/components/data-transfers/data-transfers.component.html
+++ b/src/app/components/data-transfers/data-transfers.component.html
@@ -198,7 +198,19 @@
               <div class="metadata-grid">
                 <div class="metadata-item">
                   <span class="metadata-label">Agreement ID</span>
-                  <span class="metadata-value">{{ dataTransfer.agreementId }}</span>
+                  <div class="metadata-value-action">
+                    <span class="metadata-value">{{ dataTransfer.agreementId }}</span>
+                    @if (dataTransfer.downloaded) {
+                    <button
+                      mat-icon-button
+                      matTooltip="View agreement details"
+                      (click)="openAgreementDetailsDialog(dataTransfer.agreementId)"
+                      class="action-btn"
+                    >
+                      <mat-icon>pageview</mat-icon>
+                    </button>
+                  }
+                  </div>
                 </div>
                 <div class="metadata-item">
                   <span class="metadata-label">Dataset ID</span>
@@ -393,6 +405,7 @@
                   class="action-btn action-view"
                 >
                   <mat-icon>{{ isViewing(dataTransfer['@id']) ? 'hourglass_empty' : 'pageview' }}</mat-icon>
+                  
                 </button>
                 <button
                   mat-icon-button

--- a/src/app/components/data-transfers/data-transfers.component.ts
+++ b/src/app/components/data-transfers/data-transfers.component.ts
@@ -22,6 +22,8 @@ import { DataTransfer } from '../../models/dataTransfer';
 import { DataTransferState } from '../../models/enums/dataTransferState';
 import { DataTransferService } from '../../services/data-transfer/data-transfer.service';
 import { ProxyService } from '../../services/proxy/proxy.service';
+import { MatDialog } from '@angular/material/dialog';
+import { AgreementDetailsDialogComponent } from './agreement-details-dialog/agreement-details-dialog.component';
 import {
   FilterExpansionState,
   PaginationHelper,
@@ -62,6 +64,7 @@ export class DataTransfersComponent implements OnInit, OnDestroy {
   datasetIdFilter: string = '';
   providerPidFilter: string = '';
   consumerPidFilter: string = '';
+   // Add dialog property for opening agreement details dialog
 
   // Pagination and sorting using shared utility
   paginationState: PaginationState =
@@ -94,7 +97,8 @@ export class DataTransfersComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private location: Location,
     private dataTransferService: DataTransferService,
-    private proxyService: ProxyService
+    private proxyService: ProxyService,
+    private dialog: MatDialog
   ) {}
 
   /**
@@ -500,5 +504,16 @@ export class DataTransfersComponent implements OnInit, OnDestroy {
           console.error('Error suspending contract dataTransfer:', error);
         },
       });
+  }
+
+  openAgreementDetailsDialog(agreementId: string): void {
+    this.dialog.open(AgreementDetailsDialogComponent, {
+      width: '800px',
+      maxWidth: '95vw',
+      maxHeight: '90vh',
+      autoFocus: false,
+      restoreFocus: false,
+      data: { agreementId }
+    });
   }
 }

--- a/src/app/components/policy-details/policy-details.component.html
+++ b/src/app/components/policy-details/policy-details.component.html
@@ -118,7 +118,12 @@
                     </div>
                     <div class="constraint-operand right-operand">
                       <span class="operand-label">Right Operand</span>
-                      <span class="operand-value">{{ constraint.rightOperand }}</span>
+                      <span class="operand-value"> @if(isDateConstraint(constraint)) {
+                        {{ constraint.rightOperand | date: 'd MMM y, HH:mm' }}
+                        }
+                        @else { {{ constraint.rightOperand }} }
+                      </span>
+                        <!-- {{ constraint.rightOperand }}</span> -->
                     </div>
                   </div>
                 </div>

--- a/src/app/components/policy-details/policy-details.component.ts
+++ b/src/app/components/policy-details/policy-details.component.ts
@@ -6,6 +6,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { Router, RouterModule } from '@angular/router';
+import { Constraint } from '../../models/permission';
 
 @Component({
     selector: 'app-policy-details',
@@ -74,4 +75,11 @@ export class PolicyDetailsComponent implements OnInit {
     if (!text) return '';
     return text.length > length ? text.substring(0, length) + '...' : text;
   }
+
+  /**
+   * Checks if a constraint is a date constraint
+   */
+  isDateConstraint(constraint: Constraint): boolean {
+    return constraint.leftOperand === 'DATE_TIME';
+    }
 }

--- a/src/app/models/agreement.ts
+++ b/src/app/models/agreement.ts
@@ -1,0 +1,11 @@
+import { Permission } from "./permission";
+
+export interface Agreement { 
+    '@id': string;
+    assigner: string ;
+    assignee: string ;
+    target: string ;
+    timestamp: string ;
+    permission: [Permission] ;
+    currentCount: number
+}

--- a/src/app/services/agreement/agreement.service.ts
+++ b/src/app/services/agreement/agreement.service.ts
@@ -1,0 +1,47 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { catchError, map, Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { Agreement } from '../../models/agreement';
+import { GenericApiResponse } from '../../models/genericApiResponse';
+import { ErrorHandlerService } from '../error-handler/error-handler.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AgreementService {
+  private apiUrl = environment.AGREEMENT_API_URL();
+
+  httpOptions = {
+    headers: new HttpHeaders({
+      'Content-Type': 'application/json',
+    }),
+  };
+
+  constructor(
+    private http: HttpClient,
+    private errorHandlerService: ErrorHandlerService
+  ) {}
+
+  getAgreementById(id: string): Observable<Agreement> {
+    return this.http
+      .get<GenericApiResponse<Agreement>>(`${this.apiUrl}/${id}`, this.httpOptions)
+      .pipe(
+        map((response: GenericApiResponse<Agreement>) => {
+          if (response.success && response.data) {
+
+            return response.data;
+           
+          }
+          throw new Error(response.message);
+        }),
+        catchError((error) => this.errorHandlerService.handleError(error))
+      );
+  }
+
+// private isDateString(value: string): boolean {
+//   return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(value);
+// }
+
+
+}

--- a/src/environments/environment.connectorA.ts
+++ b/src/environments/environment.connectorA.ts
@@ -13,4 +13,5 @@ export const environment = {
   PROXY_API_URL: () => `${environment.TC_ROOT_API_URL}/proxy`,
   PROPERTIES_API_URL: () => `${environment.TC_ROOT_API_URL}/properties`,
   AUDIT_API_URL: () => `${environment.TC_ROOT_API_URL}/audit`,
+  AGREEMENT_API_URL: () => `${environment.TC_ROOT_API_URL}/agreements`,
 };

--- a/src/environments/environment.connectorB.ts
+++ b/src/environments/environment.connectorB.ts
@@ -13,4 +13,5 @@ export const environment = {
   PROXY_API_URL: () => `${environment.TC_ROOT_API_URL}/proxy`,
   PROPERTIES_API_URL: () => `${environment.TC_ROOT_API_URL}/properties`,
   AUDIT_API_URL: () => `${environment.TC_ROOT_API_URL}/audit`,
+  AGREEMENT_API_URL: () => `${environment.TC_ROOT_API_URL}/agreements`,
 };

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -13,4 +13,5 @@ export const environment = {
   PROXY_API_URL: () => `${environment.TC_ROOT_API_URL}/proxy`,
   PROPERTIES_API_URL: () => `${environment.TC_ROOT_API_URL}/properties`,
   AUDIT_API_URL: () => `${environment.TC_ROOT_API_URL}/audit`,
+  AGREEMENT_API_URL: () => `${environment.TC_ROOT_API_URL}/agreements`,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -13,4 +13,5 @@ export const environment = {
   PROXY_API_URL: () => `${environment.TC_ROOT_API_URL}/proxy`,
   PROPERTIES_API_URL: () => `${environment.TC_ROOT_API_URL}/properties`,
   AUDIT_API_URL: () => `${environment.TC_ROOT_API_URL}/audit`,
+  AGREEMENT_API_URL: () => `${environment.TC_ROOT_API_URL}/agreements`,
 };


### PR DESCRIPTION
### Added

- Agreement details dialog in the Data Transfers view — clicking the Agreement ID on a completed transfer opens a modal with full agreement metadata, permissions, constraints, and remaining transfer count